### PR TITLE
Create the AbstractInvitation class.

### DIFF
--- a/invite/models.py
+++ b/invite/models.py
@@ -23,7 +23,7 @@ class InviteItem(models.Model):
         return self.first_name + ' ' + self.last_name
 
 
-class Invitation(models.Model):
+class AbstractInvitation(models.Model):
 
     def make_uuid():
         return str(uuid.uuid4())
@@ -35,38 +35,45 @@ class Invitation(models.Model):
         unique=True,
         help_text="unique id, generated on email submission",
     )
+
     first_name = models.CharField(
         max_length=36,
     )
+
     last_name = models.CharField(
         max_length=36,
     )
-    username = models.CharField(
-        max_length=36,
-    )
+
+    username = models.CharField(max_length=36)
+
     email = models.EmailField(
         max_length=41,
         help_text="the potential member's email address",
     )
-    custom_msg = models.TextField(
-        blank=True,
-    )
+
+    custom_msg = models.TextField(blank=True)
+
     date_invited = models.DateField(
         auto_now=True,
         help_text="the day on which the superuser invited the potential member",
     )
+
     permissions = models.ManyToManyField(Permission)
     groups = models.ManyToManyField(Group)
     is_super_user = models.BooleanField(default=False)
-
-    class Meta:
-        ordering = ["date_invited"]
 
     def __unicode__(self):
         return "%s, %s: %s" % (
             self.last_name,
             self.first_name,
             self.date_invited)
+
+    class Meta:
+        abstract = True
+        ordering = ["date_invited"]
+
+
+class Invitation(AbstractInvitation):
 
     def send(self):
         """Sends an invitation email to ``self.email``."""
@@ -84,14 +91,10 @@ class Invitation(models.Model):
             }
         )
 
-        send_mail(
-            subject,
-            message,
-            app_settings.INVITE_DEFAULT_FROM_EMAIL,
-            [self.email])
+        send_mail(subject, message, app_settings.INVITE_DEFAULT_FROM_EMAIL, [self.email])
 
 
-class PasswordResetInvitation(Invitation):
+class PasswordResetInvitation(AbstractInvitation):
 
     def send(self):
         """Sends an invitation email to ``self.email``."""
@@ -107,11 +110,7 @@ class PasswordResetInvitation(Invitation):
             }
         )
 
-        send_mail(
-            subject,
-            message,
-            app_settings.INVITE_DEFAULT_FROM_EMAIL,
-            [self.email])
+        send_mail(subject, message, app_settings.INVITE_DEFAULT_FROM_EMAIL, [self.email])
 
     def send_confirm(self):
         """Sends an confirmation email to ``self.email``."""
@@ -127,8 +126,4 @@ class PasswordResetInvitation(Invitation):
             }
         )
 
-        send_mail(
-            subject,
-            message,
-            app_settings.INVITE_DEFAULT_FROM_EMAIL,
-            [self.email])
+        send_mail(subject, message, app_settings.INVITE_DEFAULT_FROM_EMAIL, [self.email])


### PR DESCRIPTION
## Fixes #1

This is the same patch the was applied in PR #5.

In order to upgrade other installations with this patched version we will need to drop the existing `invite_passwordresetinvitation` table. Then we can run `syncdb` and Django will create this table sans table inheritance.
