### PR TITLE
Add migrations

### DIFF
--- a/invite/migrations/0001_initial.py
+++ b/invite/migrations/0001_initial.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Invitation',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('activation_code', models.CharField(default=uuid.uuid4, help_text=b'unique id, generated on email submission', unique=True, max_length=36, editable=False)),
+                ('first_name', models.CharField(max_length=36)),
+                ('last_name', models.CharField(max_length=36)),
+                ('username', models.CharField(max_length=36)),
+                ('email', models.EmailField(help_text=b"the potential member's email address", max_length=41)),
+                ('custom_msg', models.TextField(blank=True)),
+                ('date_invited', models.DateField(help_text=b'the day on which the superuser invited the potential member', auto_now=True)),
+                ('is_super_user', models.BooleanField(default=False)),
+            ],
+            options={
+                'ordering': ['date_invited'],
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='InviteItem',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('first_name', models.CharField(max_length=150)),
+                ('last_name', models.CharField(max_length=150)),
+                ('email', models.EmailField(max_length=150)),
+                ('username', models.CharField(max_length=150)),
+                ('greeting', models.TextField(blank=True)),
+                ('is_super_user', models.BooleanField(default=False)),
+                ('groups', models.ManyToManyField(to='auth.Group', blank=True)),
+                ('permissions', models.ManyToManyField(to='auth.Permission', blank=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='PasswordResetInvitation',
+            fields=[
+                ('invitation_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='invite.Invitation')),
+            ],
+            options={
+            },
+            bases=('invite.invitation',),
+        ),
+        migrations.AddField(
+            model_name='invitation',
+            name='groups',
+            field=models.ManyToManyField(to='auth.Group'),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='invitation',
+            name='permissions',
+            field=models.ManyToManyField(to='auth.Permission'),
+            preserve_default=True,
+        ),
+    ]

--- a/invite/migrations/0002_abstract_invitation.py
+++ b/invite/migrations/0002_abstract_invitation.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0001_initial'),
+        ('invite', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.DeleteModel('PasswordResetInvitation'),
+        migrations.CreateModel(
+            name='PasswordResetInvitation',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('activation_code', models.CharField(default=uuid.uuid4, help_text=b'unique id, generated on email submission', unique=True, max_length=36, editable=False)),
+                ('first_name', models.CharField(max_length=36)),
+                ('last_name', models.CharField(max_length=36)),
+                ('username', models.CharField(max_length=36)),
+                ('email', models.EmailField(help_text=b"the potential member's email address", max_length=41)),
+                ('custom_msg', models.TextField(blank=True)),
+                ('date_invited', models.DateField(help_text=b'the day on which the superuser invited the potential member', auto_now=True)),
+                ('is_super_user', models.BooleanField(default=False)),
+                ('groups', models.ManyToManyField(to='auth.Group')),
+                ('permissions', models.ManyToManyField(to='auth.Permission')),
+            ],
+            options={
+                'ordering': ['date_invited'],
+                'abstract': False,
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/invite/models.py
+++ b/invite/models.py
@@ -9,7 +9,8 @@ from . import settings as app_settings
 
 
 class InviteItem(models.Model):
-    '''This is the model using to generate the forms'''
+    """This is the model used to generate the forms."""
+
     first_name = models.CharField(max_length=150)
     last_name = models.CharField(max_length=150)
     email = models.EmailField(max_length=150)
@@ -24,13 +25,11 @@ class InviteItem(models.Model):
 
 
 class AbstractInvitation(models.Model):
-
-    def make_uuid():
-        return str(uuid.uuid4())
+    """Defines an abstract model with basic invitation fields."""
 
     activation_code = models.CharField(
         max_length=36,
-        default=make_uuid,
+        default=uuid.uuid4,
         editable=False,
         unique=True,
         help_text="unique id, generated on email submission",
@@ -74,6 +73,7 @@ class AbstractInvitation(models.Model):
 
 
 class Invitation(AbstractInvitation):
+    """Defines a model for new user invitations."""
 
     def send(self):
         """Sends an invitation email to ``self.email``."""
@@ -95,6 +95,7 @@ class Invitation(AbstractInvitation):
 
 
 class PasswordResetInvitation(AbstractInvitation):
+    """Defines a model for invitations created for password resets."""
 
     def send(self):
         """Sends an invitation email to ``self.email``."""

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py27-django{15,16,17}, flake8
 
 [flake8]
 max-line-length = 99
+exclude = *migrations/*
 
 [testenv]
 deps =
@@ -16,4 +17,4 @@ commands = ./manage.py test
 
 [testenv:flake8]
 deps = flake8
-commands = flake8  --ignore=E501 invite tests setup.py
+commands = flake8 invite tests setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ commands = ./manage.py test
 
 [testenv:flake8]
 deps = flake8
-commands = flake8 invite tests setup.py
+commands = flake8  --ignore=E501 invite tests setup.py


### PR DESCRIPTION
This adds an initial migration based on the original models and a migration to handle the move to using an AbstractInvitation model from which the Invitation and PasswordResetInvitation models inherit. This model change basically completely reconstructs the PasswordResetInvitation table, so the migration here drops the old table and recreates it.