### PR TITLE
Use https assets to avoid mixed content problems

### DIFF
--- a/templates/invite/base.html
+++ b/templates/invite/base.html
@@ -6,17 +6,17 @@
     <title>{% block title %}{% endblock %}</title>
     <style type="text/css"> body { padding-top: 60px; }</style>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css">
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.min.css">
-    <script type="text/javascript" src="http://code.jquery.com/jquery-latest.js"></script>
-    <script type="text/javascript" src="http://netdna.bootstrapcdn.com/twitter-bootstrap/latest/js/bootstrap.min.js"></script>
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.min.css">
+    <script type="text/javascript" src="https://code.jquery.com/jquery-latest.js"></script>
+    <script type="text/javascript" src="https://netdna.bootstrapcdn.com/twitter-bootstrap/latest/js/bootstrap.min.js"></script>
 
     <link
     rel="stylesheet"
-    href="http://code.jquery.com/ui/1.9.2/themes/base/jquery-ui.css"
+    href="https://code.jquery.com/ui/1.9.2/themes/base/jquery-ui.css"
     type="text/css"
     media="all">
-    <script src="http://code.jquery.com/ui/1.9.2/jquery-ui.js" type="text/javascript"></script>
+    <script src="https://code.jquery.com/ui/1.9.2/jquery-ui.js" type="text/javascript"></script>
 
     {% block head-extra %}{% endblock %}
 </head>


### PR DESCRIPTION
Changes http protocol and protocol-relative URLs to use https for js and css files in the 0.9.x line. This should get rid of mixed content blocking by browsers when invite app is served via https.