### PR TITLE
Show emails

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -46,3 +46,13 @@ This setting is used in the to create a customized email that is sent to the inv
 
 The 'From' field for emails sent via the Invite app.
 
+
+``INVITE_SHOW_EMAILS``
+.............................
+
+**Optional**
+
+**Default** : ``False``
+
+Whether or not to show superusers the emails associated with invitations/registrations on the accounts page.
+

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -54,5 +54,5 @@ The 'From' field for emails sent via the Invite app.
 
 **Default** : ``False``
 
-Whether or not to show superusers the emails associated with invitations/registrations on the accounts page.
+Whether or not to show superusers and users with invitation permission the emails associated with invitations/registrations on the accounts page.
 

--- a/invite/settings.py
+++ b/invite/settings.py
@@ -23,6 +23,13 @@ INVITE_DEFAULT_FROM_EMAIL = getattr(
 )
 
 
+INVITE_SHOW_EMAILS = getattr(
+    settings,
+    'INVITE_SHOW_EMAILS',
+    False
+)
+
+
 def get_service_name(request=None):
     """
     INVITE_SERVICE_NAME

--- a/invite/templates/invite/index.html
+++ b/invite/templates/invite/index.html
@@ -15,7 +15,11 @@
                 <table class='table table-striped'>
                     {% for i in invites %}
                         <tr>
-                            <td colspan='2'><i class="icon-user"></i> {{ i.first_name|title }} {{ i.last_name|title }} was <i class="icon-envelope"></i> emailed an invitation on <i class="icon-calendar"></i> {{ i.date_invited }}</td>
+                            <td colspan='2'><i class="icon-user"></i> {{ i.first_name|title }} {{ i.last_name|title }}{% if show_emails and user.is_superuser %} ({{ u.email }}){% endif %}</td>
+                            <td></td>
+                        </tr>
+                        <tr>
+                            <td colspan='2'>Invitation was <i class="icon-envelope"></i> emailed on <i class="icon-calendar"></i> {{ i.date_invited }}</td>
                             <td></td>
                         </tr>
                         {% if user.is_superuser or perms.invite.add_invitation %}
@@ -55,7 +59,7 @@
 
         {% for u in users reversed %}
             <table class='table'>
-                <code><i class="icon-user"></i> {{ u }}</code> registered on <i class="icon-calendar"></i> {{ u.date_joined.year }}-{{ u.date_joined.month }}-{{ u.date_joined.day }}
+                <code><i class="icon-user"></i> {{ u }}{% if show_emails and user.is_superuser %} ({{ u.email }}){% endif %}</code> registered on <i class="icon-calendar"></i> {{ u.date_joined.year }}-{{ u.date_joined.month }}-{{ u.date_joined.day }}
             </table>
         {% endfor %}
 

--- a/invite/templates/invite/index.html
+++ b/invite/templates/invite/index.html
@@ -15,11 +15,7 @@
                 <table class='table table-striped'>
                     {% for i in invites %}
                         <tr>
-                            <td colspan='2'><i class="icon-user"></i> {{ i.first_name|title }} {{ i.last_name|title }}{% if show_emails and user.is_superuser %} ({{ u.email }}){% endif %}</td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <td colspan='2'>Invitation was <i class="icon-envelope"></i> emailed on <i class="icon-calendar"></i> {{ i.date_invited }}</td>
+                            <td colspan='2'><i class="icon-user"></i> {{ i.first_name|title }} {{ i.last_name|title }}{% if show_emails and user.is_superuser %} ({{ u.email }}){% endif %} was <i class="icon-envelope"></i> emailed an invitation on <i class="icon-calendar"></i> {{ i.date_invited }}</td>
                             <td></td>
                         </tr>
                         {% if user.is_superuser or perms.invite.add_invitation %}

--- a/invite/templates/invite/index.html
+++ b/invite/templates/invite/index.html
@@ -15,7 +15,7 @@
                 <table class='table table-striped'>
                     {% for i in invites %}
                         <tr>
-                            <td colspan='2'><i class="icon-user"></i> {{ i.first_name|title }} {{ i.last_name|title }}{% if show_emails and user.is_superuser %} ({{ u.email }}){% endif %} was <i class="icon-envelope"></i> emailed an invitation on <i class="icon-calendar"></i> {{ i.date_invited }}</td>
+                            <td colspan='2'><i class="icon-user"></i> {{ i.first_name|title }} {{ i.last_name|title }}{% if show_emails and user.is_superuser %} ({{ i.email }}){% endif %} was <i class="icon-envelope"></i> emailed an invitation on <i class="icon-calendar"></i> {{ i.date_invited }}</td>
                             <td></td>
                         </tr>
                         {% if user.is_superuser or perms.invite.add_invitation %}

--- a/invite/templates/invite/index.html
+++ b/invite/templates/invite/index.html
@@ -15,7 +15,7 @@
                 <table class='table table-striped'>
                     {% for i in invites %}
                         <tr>
-                            <td colspan='2'><i class="icon-user"></i> {{ i.first_name|title }} {{ i.last_name|title }}{% if show_emails and user.is_superuser %} ({{ i.email }}){% endif %} was <i class="icon-envelope"></i> emailed an invitation on <i class="icon-calendar"></i> {{ i.date_invited }}</td>
+                            <td colspan='2'><i class="icon-user"></i> {{ i.first_name|title }} {{ i.last_name|title }}{% if show_emails %}{% if user.is_superuser or perms.invite.add_invitation %} ({{ i.email }}){% endif %}{% endif %} was <i class="icon-envelope"></i> emailed an invitation on <i class="icon-calendar"></i> {{ i.date_invited }}</td>
                             <td></td>
                         </tr>
                         {% if user.is_superuser or perms.invite.add_invitation %}
@@ -55,7 +55,7 @@
 
         {% for u in users reversed %}
             <table class='table'>
-                <code><i class="icon-user"></i> {{ u }}{% if show_emails and user.is_superuser %} ({{ u.email }}){% endif %}</code> registered on <i class="icon-calendar"></i> {{ u.date_joined.year }}-{{ u.date_joined.month }}-{{ u.date_joined.day }}
+                <code><i class="icon-user"></i> {{ u }}{% if show_emails %}{% if user.is_superuser or perms.invite.add_invitation %} ({{ u.email }}){% endif %}{% endif %}</code> registered on <i class="icon-calendar"></i> {{ u.date_joined.year }}-{{ u.date_joined.month }}-{{ u.date_joined.day }}
             </table>
         {% endfor %}
 

--- a/invite/views.py
+++ b/invite/views.py
@@ -163,6 +163,7 @@ def index(request):
         {
             'invites': Invitation.objects.all().order_by('-date_invited'),
             'users': User.objects.all().order_by('date_joined'),
+            'show_emails': app_settings.INVITE_SHOW_EMAILS,
         }
     )
 
@@ -187,6 +188,7 @@ def resend(request, code):
             'invites': Invitation.objects.all().order_by('-date_invited'),
             'resent_user': resent_user,
             'users': User.objects.all().order_by('date_joined'),
+            'show_emails': app_settings.INVITE_SHOW_EMAILS,
         }
     )
 

--- a/tests/settings/dev.py
+++ b/tests/settings/dev.py
@@ -1,5 +1,6 @@
 from .common import *  # noqa
 
+INVITE_SHOW_EMAILS = True
 
 DATABASES = {
     'default': {


### PR DESCRIPTION
Display to superusers the emails associated with invitations and registrations on the accounts page when the INVITE_SHOW_EMAILS setting is set to `True`.