### PR TITLE
Invitation checks and fixes

### DIFF
--- a/invite/forms.py
+++ b/invite/forms.py
@@ -22,8 +22,7 @@ def validate_user_email(value):
 
 def validate_user_email_exists(value):
     if value in User.objects.all().values_list('email', flat=True):
-        raise ValidationError(
-            'The email provided: \'%s\' already belongs to a user' % value)
+        raise ValidationError('The email provided already belongs to a user')
 
 
 class SignupForm(forms.Form):

--- a/invite/templates/invite/invite.html
+++ b/invite/templates/invite/invite.html
@@ -157,14 +157,13 @@
                             $row.prev().append(error);
                         }
                     } else {
-                        // Remove the previous error, if it exists
-                        if($row.prev("div.alert-error").filter(function() {return $(this).text().toLowerCase().indexOf(type) > -1;}).length > 0) {
-                            $row.prev().filter(function() {return $(this).text().toLowerCase().indexOf(type) > -1;}).remove();
-                        }
+                        // Remove the previous error/s, if it exists
+                        $row.prev()
+                            .children()
+                            .filter(function() {return $(this).text().toLowerCase().indexOf(type) > -1;})
+                            .remove();
                         // Remove error div, if it contains no more errors
-                        if($row.prev("div.alert-error").children("li").length === 0) {
-                            $row.prev("div.alert-error").remove();
-                        }
+                        $row.prev("div.alert-error:not(:has(li))").remove();
                     }
                 }
             };

--- a/invite/templates/invite/invite.html
+++ b/invite/templates/invite/invite.html
@@ -148,7 +148,7 @@
                             <button type="button" class="close" data-dismiss="alert">×</button>
                             {% for field in form %}
                                 {% if field.errors %}
-                                <li>{{ field.label }}: {{ field.errors|striptags }}</li>
+                                <li>{{ field.label }}: {{ field.errors.0|striptags }}</li>
                                 {% endif %}
                             {% endfor %}
                         </div>

--- a/invite/templates/invite/invite.html
+++ b/invite/templates/invite/invite.html
@@ -19,7 +19,12 @@
 
             if (formCount > 1) {
                 // Delete the item/form
-                $(btn).parents('.control-group').remove();
+                var rowToRemove = $(btn).parents('.control-group')
+                // Delete any errors that might be associated with the row
+                while (rowToRemove.prev().hasClass('alert-error')) {
+                    rowToRemove.prev().remove();
+                }
+                rowToRemove.remove();
 
                 var forms = $('#invitees .control-group'); // Get all the forms
 
@@ -122,6 +127,10 @@
 
         // Register the keyup event handler so the search boxes work
         $("#perms-search, #groups-search").keyup(searchOptions);
+
+        // With a new form, make sure only the first form row has the "add" button
+        $("#invitees button#add:gt(0)").remove();
+
     })
     </script>
 

--- a/invite/templates/invite/invite.html
+++ b/invite/templates/invite/invite.html
@@ -83,6 +83,8 @@
                 $(row).find('.delete').click(function() {
                     return deleteForm(this, prefix);
                 });
+                // Add the event handlers for the username and email validation
+                $(row).find("input[id$='username'], input[id$='email']").change(validateField);
 
                 // Update the total form count
                 $('#id_' + prefix + '-TOTAL_FORMS').val(formCount + 1);
@@ -131,6 +133,47 @@
         // With a new form, make sure only the first form row has the "add" button
         $("#invitees button#add:gt(0)").remove();
 
+        // Check to see if the username or email address is already in use, and display error if so
+        function validateField() {
+            var xhttp = new XMLHttpRequest(),
+                $input = $(this),
+                $row = $input.closest(".control-group"),
+                type = $input.attr("placeholder").toLowerCase(),
+                usernameError = $("<li></li>").text("Username: Username taken, choose another"),
+                emailError = $("<li></li>").text("Email: The email provided already belongs to a user"),
+                typeToError = {"email":emailError, "username":usernameError},
+                error = typeToError[type];
+            xhttp.onreadystatechange = function() {
+                if (this.readyState === 4 && this.status === 200) {
+                    var taken = JSON.parse(this.responseText).taken;
+                    if (taken === true) {
+                        var errorDiv = $("<div class='alert alert-error'><button type='button' class='close' data-dismiss='alert'>×</button></div>");
+                        // Create the error div, if it isn't there already
+                        if (!$row.prev().hasClass("alert-error")) {
+                            $row.before(errorDiv);
+                        }
+                        // Add the error to the error list, if it isn't there already
+                        if ($row.prev().find(":contains('" + error.text() + "')").length === 0) {
+                            $row.prev().append(error);
+                        }
+                    } else {
+                        // Remove the previous error, if it exists
+                        if($row.prev("div.alert-error").filter(function() {return $(this).text().toLowerCase().indexOf(type) > -1;}).length > 0) {
+                            $row.prev().filter(function() {return $(this).text().toLowerCase().indexOf(type) > -1;}).remove();
+                        }
+                        // Remove error div, if it contains no more errors
+                        if($row.prev("div.alert-error").children("li").length === 0) {
+                            $row.prev("div.alert-error").remove();
+                        }
+                    }
+                }
+            };
+            xhttp.open("GET", "/check/?" + type + "=" + $(this).val(), true);
+            xhttp.send();
+        }
+
+        $("input[id$='username'], input[id$='email']").change(validateField);
+
     })
     </script>
 
@@ -138,7 +181,7 @@
 
 {% block content %}
     {% if perms.invite.add_invitation %}
-        <h3>Whom would you like to invite, {{ request.user|title }}?</h3>
+        <h3>Whom would you like to invite, {{ user|title }}?</h3>
         <form id='invite' class="navbar-form form-horizontal" method="POST">{% csrf_token %}
             {{ invite_item_formset.management_form }}
             <div class='well well-small' id="invitees">

--- a/invite/templates/invite/invite.html
+++ b/invite/templates/invite/invite.html
@@ -168,7 +168,7 @@
                     }
                 }
             };
-            xhttp.open("GET", "/check/?" + type + "=" + $(this).val(), true);
+            xhttp.open("GET", "{% url 'invite:check' %}?" + type + "=" + $(this).val(), true);
             xhttp.send();
         }
 

--- a/invite/templates/invite/invite.html
+++ b/invite/templates/invite/invite.html
@@ -20,10 +20,8 @@
             if (formCount > 1) {
                 // Delete the item/form
                 var rowToRemove = $(btn).parents('.control-group')
-                // Delete any errors that might be associated with the row
-                while (rowToRemove.prev().hasClass('alert-error')) {
-                    rowToRemove.prev().remove();
-                }
+                // Delete error list that might be associated with the row
+                rowToRemove.prev('.alert-error').remove()
                 rowToRemove.remove();
 
                 var forms = $('#invitees .control-group'); // Get all the forms
@@ -135,14 +133,14 @@
 
         // Check to see if the username or email address is already in use, and display error if so
         function validateField() {
-            var xhttp = new XMLHttpRequest(),
-                $input = $(this),
-                $row = $input.closest(".control-group"),
-                type = $input.attr("placeholder").toLowerCase(),
-                usernameError = $("<li></li>").text("Username: Username taken, choose another"),
-                emailError = $("<li></li>").text("Email: The email provided already belongs to a user"),
-                typeToError = {"email":emailError, "username":usernameError},
-                error = typeToError[type];
+            var xhttp = new XMLHttpRequest();
+            var $input = $(this);
+            var $row = $input.closest(".control-group");
+            var type = $input.attr("placeholder").toLowerCase();
+            var usernameError = $("<li></li>").text("Username: Username taken, choose another");
+            var emailError = $("<li></li>").text("Email: The email provided already belongs to a user");
+            var typeToError = {"email":emailError, "username":usernameError};
+            var error = typeToError[type];
             xhttp.onreadystatechange = function() {
                 if (this.readyState === 4 && this.status === 200) {
                     var taken = JSON.parse(this.responseText).taken;

--- a/invite/templates/invite/invite.html
+++ b/invite/templates/invite/invite.html
@@ -90,14 +90,27 @@
             return false;
         }
 
+        function disableSubmit() {
+            $("#invite-button").removeClass("btn-primary").addClass("btn-inverse disabled");
+        }
+
+        function enableSubmit() {
+            $("#invite-button").removeClass("btn-inverse disabled").addClass("btn-primary");
+        }
+
+        // Disable the submit button if there are initial errors.
+        if ($("div.alert-error").length > 0) {
+            disableSubmit();
+        }
+
         $("#invite").on('submit',function(e){
             var $form = $(this);
-            if ($form.data('submitted') === true) {
+            if ($form.data('submitted') === true || $("div.alert-error").length > 0) {
                 // Previously submitted - don't submit again
                 e.preventDefault();
             } else {
                 // Mark it so that the next submit can be ignored
-                $("#invite-button").removeClass("btn-primary").addClass("btn-inverse").addClass("disabled");
+                disableSubmit();
                 $form.data('submitted', true);
             }
         });
@@ -145,10 +158,11 @@
                 if (this.readyState === 4 && this.status === 200) {
                     var taken = JSON.parse(this.responseText).taken;
                     if (taken === true) {
-                        var errorDiv = $("<div class='alert alert-error'><button type='button' class='close' data-dismiss='alert'>×</button></div>");
+                        var errorDiv = $("<div class='alert alert-error'></div>");
                         // Create the error div, if it isn't there already
                         if (!$row.prev().hasClass("alert-error")) {
                             $row.before(errorDiv);
+                            disableSubmit();
                         }
                         // Add the error to the error list, if it isn't there already
                         if ($row.prev().find(":contains('" + error.text() + "')").length === 0) {
@@ -162,6 +176,10 @@
                             .remove();
                         // Remove error div, if it contains no more errors
                         $row.prev("div.alert-error:not(:has(li))").remove();
+                        // Enable submit button if all errors are gone from all rows
+                        if ($("div.alert-error").length === 0) {
+                            enableSubmit();
+                        }
                     }
                 }
             };
@@ -185,7 +203,6 @@
                 {% for form in invite_item_formset %}
                      {% if form.errors %}
                         <div class="alert alert-error">
-                            <button type="button" class="close" data-dismiss="alert">×</button>
                             {% for field in form %}
                                 {% if field.errors %}
                                 <li>{{ field.label }}: {{ field.errors.0|striptags }}</li>

--- a/invite/urls.py
+++ b/invite/urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
     url(r'^reset/$', views.reset, name='reset'),
     url(r'^signup/$', views.signup, name='account_signup'),
     url(r'^about/$', views.about, name='about'),
+    url(r'^check/$', views.check, name='check'),
 ]

--- a/invite/views.py
+++ b/invite/views.py
@@ -1,9 +1,9 @@
 from django.shortcuts import render
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.forms.formsets import formset_factory, BaseFormSet
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, JsonResponse
 from django.contrib.auth import authenticate, login
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth import logout
 from django.contrib.auth.models import User
 from django.views.decorators.csrf import csrf_protect
@@ -366,3 +366,23 @@ def signup(request):
             'activation_code': code,
         }
     )
+
+
+@permission_required('invite.add_invitation', raise_exception=True)
+def check(request):
+    """Check to see if username or email address is taken by a user."""
+    if request.GET.get('username', None):
+        try:
+            User.objects.get(username__iexact=request.GET['username'].strip())
+            result = True
+        except:
+            result = False
+    elif request.GET.get('email', None):
+        try:
+            User.objects.get(email__iexact=request.GET['email'].strip())
+            result = True
+        except:
+            result = False
+    else:
+        result = False
+    return JsonResponse({'taken': result})

--- a/invite/views.py
+++ b/invite/views.py
@@ -375,13 +375,13 @@ def check(request):
         try:
             User.objects.get(username__iexact=request.GET['username'].strip())
             result = True
-        except:
+        except User.DoesNotExist:
             result = False
     elif request.GET.get('email', None):
         try:
             User.objects.get(email__iexact=request.GET['email'].strip())
             result = True
-        except:
+        except User.DoesNotExist:
             result = False
     else:
         result = False

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -419,7 +419,7 @@ class TestViews(TestCase):
         )
         for each in taken:
             response = self.client.get(reverse('invite:check'), each)
-            self.assertTrue(json.loads(response.content)['taken'] is True)
+            self.assertTrue(json.loads(response.content)['taken'])
 
     def test_check_returns_false_when_not_taken(self):
         self.client.login(username='superuser', password='superuser')
@@ -431,17 +431,12 @@ class TestViews(TestCase):
         )
         for each in not_taken:
             response = self.client.get(reverse('invite:check'), each)
-            self.assertTrue(json.loads(response.content)['taken'] is False)
+            self.assertFalse(json.loads(response.content)['taken'])
 
     def test_check_returns_false_with_no_args(self):
         self.client.login(username='superuser', password='superuser')
         response = self.client.get(reverse('invite:check'))
-        self.assertTrue(json.loads(response.content)['taken'] is False)
-
-    def test_check_returns_false_with_unrecognized_args(self):
-        self.client.login(username='superuser', password='superuser')
-        response = self.client.get(reverse('invite:check'), {'rand': 'rand'})
-        self.assertTrue(json.loads(response.content)['taken'] is False)
+        self.assertFalse(json.loads(response.content)['taken'])
 
 
 if __name__ == '__main__':

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,7 @@
 import datetime
 import unittest
 import mock
+import json
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -398,6 +399,49 @@ class TestViews(TestCase):
         self.assertNotIn('superuser@superuser.superuser', response.content)
         self.assertNotIn('alpha@alpha.alpha', response.content)
         self.assertNotIn('bravo@bravo.bravo', response.content)
+
+    def test_check_requires_permission(self):
+        self.client.login(username='superuser', password='superuser')
+        response = self.client.get(reverse('invite:check'))
+        self.assertTrue(response.status_code == 200)
+        self.client.logout()
+        self.client.login(username='normal', password='normal')
+        response = self.client.get(reverse('invite:check'))
+        self.assertTrue(response.status_code == 403)
+
+    def test_check_returns_true_when_taken(self):
+        self.client.login(username='superuser', password='superuser')
+        taken = (
+            {'username': self.normal_user.username},
+            {'username': self.supertwo.username},
+            {'email': self.normal_user.email},
+            {'email': self.supertwo.email},
+        )
+        for each in taken:
+            response = self.client.get(reverse('invite:check'), each)
+            self.assertTrue(json.loads(response.content)['taken'] is True)
+
+    def test_check_returns_false_when_not_taken(self):
+        self.client.login(username='superuser', password='superuser')
+        not_taken = (
+            {'username': 'doesnotexist'},
+            {'username': ''},
+            {'email': 'nothing@nothing.nothing'},
+            {'email': 'test@test.test'},
+        )
+        for each in not_taken:
+            response = self.client.get(reverse('invite:check'), each)
+            self.assertTrue(json.loads(response.content)['taken'] is False)
+
+    def test_check_returns_false_with_no_args(self):
+        self.client.login(username='superuser', password='superuser')
+        response = self.client.get(reverse('invite:check'))
+        self.assertTrue(json.loads(response.content)['taken'] is False)
+
+    def test_check_returns_false_with_unrecognized_args(self):
+        self.client.login(username='superuser', password='superuser')
+        response = self.client.get(reverse('invite:check'), {'rand': 'rand'})
+        self.assertTrue(json.loads(response.content)['taken'] is False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds a check on the username and email fields that will alert the user (upon losing focus on that field) that the value is taken by another user already. This also addresses an inconsistent way to display usernames that wasn't always working, removes duplicate error messages in returned forms, and adds a new view (to implement the checks).