### PR TITLE
Redirect to login page after password reset.

### DIFF
--- a/invite/views.py
+++ b/invite/views.py
@@ -35,10 +35,14 @@ def reset(request):
                 password=form.cleaned_data['password'],
             )
             if user is not None:
-                login(request, user)
-                # Redirect to main edit dashboard
-                return HttpResponseRedirect(
-                    app_settings.INVITE_SIGNUP_SUCCESS_URL)
+                form = forms.LoginForm()
+                return render(
+                    request,
+                    'invite/login.html',
+                    {
+                        'login_form': form,
+                    }
+                )
             else:
                 return render(
                     request,

--- a/invite/views.py
+++ b/invite/views.py
@@ -35,14 +35,7 @@ def reset(request):
                 password=form.cleaned_data['password'],
             )
             if user is not None:
-                form = forms.LoginForm()
-                return render(
-                    request,
-                    'invite/login.html',
-                    {
-                        'login_form': form,
-                    }
-                )
+                return HttpResponseRedirect(reverse('invite:login'))
             else:
                 return render(
                     request,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -317,7 +317,7 @@ class TestViews(TestCase):
             follow=True
         )
         self.assertEqual(200, response.status_code)
-        self.assertIn('Log out', response.content.decode())
+        self.assertIn('Log in', response.content.decode())
 
     def test_reset_inactive_user(self):
         pri = PasswordResetInvitation.objects.create(
@@ -360,7 +360,7 @@ class TestViews(TestCase):
             {'password': 'kookaburra', 'password2': 'kookaburra'},
             follow=True
         )
-        self.assertIn('Log out', response.content.decode())
+        self.assertIn('Log in', response.content.decode())
 
     @unittest.mock.patch('invite.views.app_settings')
     def test_index_shows_limited_invites(self, mock_settings):


### PR DESCRIPTION
@ldko @somexpert 
After resetting the password the user is redirected to login page (instead of directly logging in the user). 
This closes #50 