### PR TITLE
Skip non-existing forms

### DIFF
--- a/invite/templates/invite/invite.html
+++ b/invite/templates/invite/invite.html
@@ -115,11 +115,6 @@
             }
         });
 
-        window.onload = function() {
-            document.getElementById('invite').reset();
-            $('#id_form-TOTAL_FORMS').val(1);
-        }
-
         // Register the click event handlers
         $("#add").click(function() {
             return addForm(this, 'form');

--- a/invite/templates/invite/invite.html
+++ b/invite/templates/invite/invite.html
@@ -115,6 +115,11 @@
             }
         });
 
+        window.onload = function() {
+            document.getElementById('invite').reset();
+            $('#id_form-TOTAL_FORMS').val(1);
+        }
+
         // Register the click event handlers
         $("#add").click(function() {
             return addForm(this, 'form');

--- a/invite/views.py
+++ b/invite/views.py
@@ -280,34 +280,34 @@ def invite(request):
                         email=form.cleaned_data['email'],
                         is_super_user=form.cleaned_data['is_super_user'],
                     )
-                    i.custom_msg = (
-                        invite_item_formset
-                        .forms[0]
-                        .cleaned_data['greeting']
-                    )
-                    # set m2m relationships from initial object creation
-                    permissions = (
-                        invite_item_formset
-                        .forms[0]
-                        .cleaned_data['permissions']
-                    )
-                    groups = (
-                        invite_item_formset
-                        .forms[0]
-                        .cleaned_data['groups']
-                    )
-
-                    for permission in permissions:
-                        i.permissions.add(permission)
-                    for group in groups:
-                        i.groups.add(group)
-                    # send the email invitation
-                    i.send(request=request)
-                    i.save()
                 except KeyError:
                     # except KeyError due to possible incorrect form count
                     # due to user refreshing and re-submitting forms
                     continue
+                i.custom_msg = (
+                    invite_item_formset
+                    .forms[0]
+                    .cleaned_data['greeting']
+                )
+                # set m2m relationships from initial object creation
+                permissions = (
+                    invite_item_formset
+                    .forms[0]
+                    .cleaned_data['permissions']
+                )
+                groups = (
+                    invite_item_formset
+                    .forms[0]
+                    .cleaned_data['groups']
+                )
+
+                for permission in permissions:
+                    i.permissions.add(permission)
+                for group in groups:
+                    i.groups.add(group)
+                # send the email invitation
+                i.send(request=request)
+                i.save()
             return HttpResponseRedirect(reverse('invite:index'))
     else:
         invite_item_formset = InviteItemFormSet()

--- a/invite/views.py
+++ b/invite/views.py
@@ -271,38 +271,43 @@ def invite(request):
         invite_item_formset = InviteItemFormSet(request.POST, request.FILES)
         if invite_item_formset.is_valid():
             for form in invite_item_formset.forms:
-                # make invite for each form
-                i = Invitation.objects.create(
-                    first_name=form.cleaned_data['first_name'],
-                    last_name=form.cleaned_data['last_name'],
-                    username=form.cleaned_data['username'],
-                    email=form.cleaned_data['email'],
-                    is_super_user=form.cleaned_data['is_super_user'],
-                )
-                i.custom_msg = (
-                    invite_item_formset
-                    .forms[0]
-                    .cleaned_data['greeting']
-                )
-                # set m2m relationships from initial object creation
-                permissions = (
-                    invite_item_formset
-                    .forms[0]
-                    .cleaned_data['permissions']
-                )
-                groups = (
-                    invite_item_formset
-                    .forms[0]
-                    .cleaned_data['groups']
-                )
+                try:
+                    # make invite for each form
+                    i = Invitation.objects.create(
+                        first_name=form.cleaned_data['first_name'],
+                        last_name=form.cleaned_data['last_name'],
+                        username=form.cleaned_data['username'],
+                        email=form.cleaned_data['email'],
+                        is_super_user=form.cleaned_data['is_super_user'],
+                    )
+                    i.custom_msg = (
+                        invite_item_formset
+                        .forms[0]
+                        .cleaned_data['greeting']
+                    )
+                    # set m2m relationships from initial object creation
+                    permissions = (
+                        invite_item_formset
+                        .forms[0]
+                        .cleaned_data['permissions']
+                    )
+                    groups = (
+                        invite_item_formset
+                        .forms[0]
+                        .cleaned_data['groups']
+                    )
 
-                for permission in permissions:
-                    i.permissions.add(permission)
-                for group in groups:
-                    i.groups.add(group)
-                # send the email invitation
-                i.send(request=request)
-                i.save()
+                    for permission in permissions:
+                        i.permissions.add(permission)
+                    for group in groups:
+                        i.groups.add(group)
+                    # send the email invitation
+                    i.send(request=request)
+                    i.save()
+                except KeyError:
+                    # except KeyError due to possible incorrect form count
+                    # due to user refreshing and re-submitting forms
+                    continue
             return HttpResponseRedirect(reverse('invite:index'))
     else:
         invite_item_formset = InviteItemFormSet()


### PR DESCRIPTION
This should fix #59. We will skip the forms that don't actually have input values. The form count is different than what the user sees when they use the reload/refresh invite page that they had just submitted. This fix will allow them to resubmit or submit new invitations from the reloaded page. If they add new forms, those are validated.