### PR TITLE
Reuse signup redirect for reset password redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ Change Log
 
 5.0.0
 -----
-* Upgraded Django support from 2.2 to 4.2
-* Dropped support for Python 3.7
+* Upgraded Django support from 2.2 to 4.2.
+* Dropped support for Python 3.7.
+* Set same redirect URL for password resets as for setting an initial password.
 
 4.1.0
 -----

--- a/invite/views.py
+++ b/invite/views.py
@@ -36,7 +36,7 @@ def reset(request):
                 password=form.cleaned_data['password'],
             )
             if user is not None:
-                return HttpResponseRedirect(reverse('invite:login'))
+                return HttpResponseRedirect(app_settings.INVITE_SIGNUP_SUCCESS_URL)
             else:
                 return render(
                     request,


### PR DESCRIPTION
This just changes the URL a user gets redirected to when submitting a successful change password form to use the same setting that is used when a new user sets their password for the first time. For our Edit site, which uses the invite app, it has been going to the login form of the invite app, but since we use it for Edit users to generally reset their password, we want to be able to configure it to go to the Edit site login view instead.

ping @clarktr1 @somexpert @htarver  this is ready for review