### PR TITLE
Restrict request methods and add more tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Change Log
 * Set same redirect URL for password resets as for setting an initial password.
 * Added some exception handling and error messages for cases where emails fail to send.
 * Update the date_invited field when resending invitations.
+* Restrict the allowed request types for certain URLs.
+* Add tests for some previously untested views.
 
 4.1.0
 -----

--- a/invite/views.py
+++ b/invite/views.py
@@ -7,6 +7,7 @@ from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth import logout
 from django.contrib.auth.models import User
 from django.views.decorators.csrf import csrf_protect
+from django.views.decorators.http import require_http_methods
 
 from . import forms
 from .models import Invitation, PasswordResetInvitation
@@ -15,6 +16,7 @@ from .utils import get_cutoff_date
 from datetime import date
 
 
+@require_http_methods(['GET', 'POST'])
 def reset(request):
     '''Reset django user password.'''
     if request.method == 'POST':
@@ -60,7 +62,7 @@ def reset(request):
                     'reset_code': reset_code,
                 }
             )
-    elif request.method == 'GET':
+    else:
         # they come bearing a reset_code
         if 'reset_code' in request.GET.keys():
             try:
@@ -108,6 +110,7 @@ def reset(request):
             )
 
 
+@require_http_methods(['GET', 'POST'])
 def amnesia(request):
     # iforgot form.
     if request.method == 'POST':
@@ -218,6 +221,7 @@ def index(request):
     )
 
 
+@require_http_methods(['GET'])
 @login_required(redirect_field_name=None,
                 login_url=reverse_lazy('invite:login'))
 def resend(request, code):
@@ -263,6 +267,7 @@ def resend(request, code):
     )
 
 
+@require_http_methods(['GET'])
 @login_required(redirect_field_name=None,
                 login_url=reverse_lazy('invite:login'))
 def revoke(request, code):


### PR DESCRIPTION
This adds tests for the previously untested revoke view and also restricts the request methods for some views which can make changes to the models. This is in response to errors received by someone sending a HEAD request to the reset view, which has conditionals only for POST and GET, leading to the view returning None, which causes the error. This approach of restricting the request methods seems better than allowing all types, which would mean we would either be allowing HEAD requests to inadvertently delete invites and do things like that, or we'd need to add more code for some of the views to change what they do on different kinds of requests to avoid those unintended consequences.