### PR TITLE
fix duplicate email invite form error, adds tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ Contributors:
 - [Lauren Ko](http://github.com/ldko)
 - [Gio Gottardi](http://github.com/somexpert)
 - [Madhulika Bayyavarapu](http://github.com/madhulika95b)
+- [Trey Clark](http://github.com/clarktr1)

--- a/invite/forms.py
+++ b/invite/forms.py
@@ -8,6 +8,9 @@ from django.core.exceptions import ValidationError
 def validate_username(value):
     if User.objects.filter(username__iexact=value).exists():
         raise ValidationError(f'Username {value} taken, choose another')
+
+
+def validate_username_invitation(value):
     if Invitation.objects.filter(username__iexact=value).exists():
         raise ValidationError(f'Username {value} taken, choose another')
 
@@ -149,7 +152,7 @@ class InviteItemForm(forms.ModelForm):
     # an order
 
     username = forms.CharField(
-        validators=[validate_username],
+        validators=[validate_username, validate_username_invitation],
         max_length=30,
         widget=forms.TextInput(
             attrs={

--- a/invite/forms.py
+++ b/invite/forms.py
@@ -11,8 +11,8 @@ def validate_username(value):
 
 
 def validate_user_email(value):
-    if User.objects.filter(email__iexact=value).exists():
-        raise ValidationError(f'{value} provided doesn\'t belong to any user')
+    if not User.objects.filter(email__iexact=value).exists():
+        raise ValidationError('The email provided doesn\'t belong to any user')
 
 
 def validate_email_exists(value):
@@ -115,9 +115,7 @@ class SignupForm(forms.Form):
 
 class BaseInviteItemFormSet(forms.BaseFormSet):
     def clean(self):
-        """
-        Validate that there are no duplicate email addresses across forms.
-        """
+        """Validate that there are no duplicate email addresses across forms."""
         super().clean()
         emails = []
         users = []
@@ -259,6 +257,7 @@ class LoginForm(forms.Form):
 
 class IForgotForm(forms.Form):
     email = forms.EmailField(
+        validators=[validate_user_email],
         widget=forms.TextInput(
             attrs={
                 'class': 'form-control',
@@ -269,10 +268,6 @@ class IForgotForm(forms.Form):
     )
 
     def clean_email(self):
-        insensitive_emails = [e.lower() for e in User.objects.all().values_list('email', flat=True)]  # noqa
-        if self.data['email'].lower() not in insensitive_emails:
-            raise ValidationError(
-                'The email provided doesn\'t belong to any user')
         return self.data['email']
 
     def clean(self, *args, **kwargs):

--- a/invite/templates/invite/invite.html
+++ b/invite/templates/invite/invite.html
@@ -151,7 +151,8 @@
             var $row = $input.closest(".control-group");
             var type = $input.attr("placeholder").toLowerCase();
             var usernameError = $("<li></li>").text("Username: Username taken, choose another");
-            var emailError = $("<li></li>").text("Email: The email provided already belongs to a user");
+            var emailError = $("<li></li>").text(`Email: ${$input.val()} already belongs to a User or pending invite `);
+            console.log($input)
             var typeToError = {"email":emailError, "username":usernameError};
             var error = typeToError[type];
             xhttp.onreadystatechange = function() {
@@ -165,18 +166,22 @@
                             disableSubmit();
                         }
                         // Add the error to the error list, if it isn't there already
-                        if ($row.prev().find(":contains('" + error.text() + "')").length === 0) {
+                        if ($row.prev().find(":contains('Email:'), :contains('Username:')").length === 0) {
                             $row.prev().append(error);
                         }
                     } else {
-                        // Remove the previous error/s, if it exists
+                        // Remove previous errors, if they exist
                         $row.prev()
                             .children()
-                            .filter(function() {return $(this).text().toLowerCase().indexOf(type) > -1;})
+                            .filter(function () {
+                                const text = $(this).text().toLowerCase();
+                                console.log("Checking text for removal:", text); // Debugging log
+                                return text.indexOf("email") > -1 || text.indexOf("username:") > -1;
+                            })
                             .remove();
-                        // Remove error div, if it contains no more errors
+                        // Remove error div if it contains no more errors
                         $row.prev("div.alert-error:not(:has(li))").remove();
-                        // Enable submit button if all errors are gone from all rows
+                        // Enable submit button if no errors are present in all rows
                         if ($("div.alert-error").length === 0) {
                             enableSubmit();
                         }
@@ -197,6 +202,15 @@
 {% block content %}
     {% if perms.invite.add_invitation %}
         <h3>Whom would you like to invite, {{ user|title }}?</h3>
+        {% if errors %}
+        <div class="alert">
+            <ul>
+                {% for error in errors %}
+                        <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+        {% endif %}
         <form id='invite' class="navbar-form form-horizontal" method="POST">{% csrf_token %}
             {{ invite_item_formset.management_form }}
             <div class='well well-small' id="invitees">

--- a/invite/templates/invite/invite.html
+++ b/invite/templates/invite/invite.html
@@ -152,7 +152,6 @@
             var type = $input.attr("placeholder").toLowerCase();
             var usernameError = $("<li></li>").text("Username: Username taken, choose another");
             var emailError = $("<li></li>").text(`Email: ${$input.val()} already belongs to a User or pending invite `);
-            console.log($input)
             var typeToError = {"email":emailError, "username":usernameError};
             var error = typeToError[type];
             xhttp.onreadystatechange = function() {
@@ -175,7 +174,6 @@
                             .children()
                             .filter(function () {
                                 const text = $(this).text().toLowerCase();
-                                console.log("Checking text for removal:", text); // Debugging log
                                 return text.indexOf("email") > -1 || text.indexOf("username:") > -1;
                             })
                             .remove();

--- a/invite/templates/invite/invite.html
+++ b/invite/templates/invite/invite.html
@@ -201,7 +201,7 @@
     {% if perms.invite.add_invitation %}
         <h3>Whom would you like to invite, {{ user|title }}?</h3>
         {% if errors %}
-        <div class="alert">
+        <div class="alert" style="background-color: #f2dede; color: #b94a48; border-color: #eed3d7;">
             <ul>
                 {% for error in errors %}
                         <li>{{ error }}</li>

--- a/invite/views.py
+++ b/invite/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render
 from django.urls import reverse, reverse_lazy
-from django.forms.formsets import formset_factory, BaseFormSet
+from django.forms.formsets import formset_factory
 from django.http import HttpResponseRedirect, JsonResponse, HttpResponseServerError
 from django.contrib.auth import authenticate, login
 from django.contrib.auth.decorators import login_required, permission_required
@@ -293,7 +293,7 @@ def invite(request):
     if request.method == 'POST':
         # Create a formset from the submitted data
         invite_item_formset = InviteItemFormSet(request.POST, request.FILES)
-        
+
         if invite_item_formset.is_valid():
             for form in invite_item_formset.forms:
                 try:

--- a/invite/views.py
+++ b/invite/views.py
@@ -340,7 +340,6 @@ def invite(request):
                 i.save()
             return HttpResponseRedirect(reverse('invite:index'))
         else:
-            print(invite_item_formset.errors)
             return render(
                 request,
                 'invite/invite.html',

--- a/invite/views.py
+++ b/invite/views.py
@@ -288,11 +288,12 @@ def revoke(request, code):
 def invite(request):
     InviteItemFormSet = formset_factory(
         forms.InviteItemForm,
-        formset=BaseFormSet,
+        formset=forms.BaseInviteItemFormSet,
     )
     if request.method == 'POST':
         # Create a formset from the submitted data
         invite_item_formset = InviteItemFormSet(request.POST, request.FILES)
+        
         if invite_item_formset.is_valid():
             for form in invite_item_formset.forms:
                 try:
@@ -338,6 +339,16 @@ def invite(request):
                     )
                 i.save()
             return HttpResponseRedirect(reverse('invite:index'))
+        else:
+            print(invite_item_formset.errors)
+            return render(
+                request,
+                'invite/invite.html',
+                {
+                    'invite_item_formset': invite_item_formset,
+                    'errors': invite_item_formset.non_form_errors(),
+                }
+            )
     else:
         invite_item_formset = InviteItemFormSet()
     return render(
@@ -439,9 +450,14 @@ def check(request):
     elif request.GET.get('email', None):
         try:
             User.objects.get(email__iexact=request.GET['email'].strip())
-            result = True
+            user_result = True
         except User.DoesNotExist:
-            result = False
+            user_result = False
+        if Invitation.objects.filter(email__iexact=request.GET['email'].strip()).exists():
+            invitation_result = True
+        else:
+            invitation_result = False
+        result = user_result or invitation_result
     else:
         result = False
     return JsonResponse({'taken': result})

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -363,8 +363,8 @@ class TestViews(TestCase):
         self.assertIn('already belongs to a user', response.content.decode())
         self.assertEqual(len(mail.outbox), 0)
 
-    def test_invite_invitation_duplicate_email(self):
-        """"Test for duplicate emails in pending Invitations."""
+    def test_invite_invitation_duplicate_email_and_username(self):
+        """"Test for duplicate emails and usernames in pending Invitations."""
         self.client.login(username='superuser', password='superuser')
         self.client.post(
             reverse('invite:invite'),
@@ -372,7 +372,7 @@ class TestViews(TestCase):
                 'form-MAX_NUM_FORMS': [''],
                 'form-INITIAL_FORMS': ['0'],
                 'form-TOTAL_FORMS': ['1'],
-                'form-0-username': ['bobby'],
+                'form-0-username': ['bobby1'],
                 'form-0-email': ['test1@test.com'],
                 'form-0-last_name': ['test1'],
                 'form-0-first_name': ['test1'],
@@ -385,7 +385,7 @@ class TestViews(TestCase):
                 'form-MAX_NUM_FORMS': [''],
                 'form-INITIAL_FORMS': ['0'],
                 'form-TOTAL_FORMS': ['1'],
-                'form-0-username': ['bobby'],
+                'form-0-username': ['bobby1'],
                 'form-0-email': ['test1@test.com'],
                 'form-0-last_name': ['test1'],
                 'form-0-first_name': ['test1'],
@@ -393,6 +393,7 @@ class TestViews(TestCase):
             },
         )
         self.assertIn('test1@test.com already belongs', response.content.decode())
+        self.assertIn('Username bobby1 taken, choose another', response.content.decode())
 
     def test_invitation_duplicates_and_clean(self):
         """"Test for duplicate email/username in InviteForm and clean_email method."""
@@ -415,8 +416,8 @@ class TestViews(TestCase):
                 'form-1-greeting': [''],
             }
         )
-        self.assertIn('Email: email@email.com is already in this form', response.content.decode())
-        self.assertIn('Username: test1 is already in this form', response.content.decode())
+        self.assertIn('Email: email@email.com is duplicated', response.content.decode())
+        self.assertIn('Username: test1 is duplicated', response.content.decode())
 
     def test_reset_submit(self):
         psi = PasswordResetInvitation.objects.create(

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -415,8 +415,8 @@ class TestViews(TestCase):
                 'form-1-greeting': [''],
             }
         )
-        self.assertIn('Email: email@email.com already belongs to another invitation in the current form', response.content.decode())
-        self.assertIn('Username: test1 already belongs to another invitation in the current form', response.content.decode())
+        self.assertIn('Email: email@email.com is already in this form', response.content.decode())
+        self.assertIn('Username: test1 is already in this form', response.content.decode())
 
     def test_reset_submit(self):
         psi = PasswordResetInvitation.objects.create(

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -21,7 +21,7 @@ settings.SITE_ID = 1
 class TestOperations(TestCase):
 
     def test_invite_creation(self):
-        """Creates an invite and check to see if we can send the email"""
+        """Creates an invite and check to see if we can send the email."""
         i = Invitation.objects.create(
             email='joeyliechty@supergreatmail.com',
         )
@@ -33,7 +33,7 @@ class TestOperations(TestCase):
         """
         Since we trust the django mailer, and we don't want to do time wasting
         tests that do actual network activity, we'll use mock to ensure that
-        the mailer is called with the correct arguments by the model
+        the mailer is called with the correct arguments by the model.
         """
         i = Invitation.objects.create(
             email='1234testemail@noone.ghost',
@@ -65,7 +65,7 @@ class TestOperations(TestCase):
         """
         Since we trust the django mailer, and we don't want to do time wasting
         tests that do actual network activity, we'll use mock to ensure that
-        the mailer is called with the correct arguments by the model
+        the mailer is called with the correct arguments by the model.
         """
         i = PasswordResetInvitation.objects.create(
             email='1234testemail@noone.ghost',
@@ -345,7 +345,7 @@ class TestViews(TestCase):
         self.assertIn('Email exists on other user', response.content.decode())
 
     def test_invite_user_duplicate_email(self):
-        """" Test for Inivtation email matching current User email """
+        """Test for Invitation email matching current User email."""
         self.client.login(username='superuser', password='superuser')
         response = self.client.post(
             reverse('invite:invite'),
@@ -364,7 +364,7 @@ class TestViews(TestCase):
         self.assertEqual(len(mail.outbox), 0)
 
     def test_invite_invitation_duplicate_email(self):
-        """" Test for duplicate emails in pending Invitations """
+        """"Test for duplicate emails in pending Invitations."""
         self.client.login(username='superuser', password='superuser')
         self.client.post(
             reverse('invite:invite'),
@@ -392,24 +392,24 @@ class TestViews(TestCase):
                 'form-0-greeting': ['']
             },
         )
-        self.assertIn('test1@test.com already belongs to a pending invitation', response.content.decode())
+        self.assertIn('test1@test.com already belongs', response.content.decode())
 
     def test_invitation_duplicates_and_clean(self):
-        """" Test for duplicate email/username in InviteForm and clean_email method """
+        """"Test for duplicate email/username in InviteForm and clean_email method."""
         self.client.login(username='superuser', password='superuser')
         response = self.client.post(
             reverse('invite:invite'),
             {
                 'form-MAX_NUM_FORMS': [''],
                 'form-INITIAL_FORMS': ['0'],
-                'form-TOTAL_FORMS': ['2'], 
+                'form-TOTAL_FORMS': ['2'],
                 'form-0-username': ['test1'],
                 'form-0-email': ['EMAIL@EMAIL.com'],
                 'form-0-last_name': ['test1'],
                 'form-0-first_name': ['test1'],
                 'form-0-greeting': [''],
                 'form-1-username': ['test1'],
-                'form-1-email': ['email@email.com'],  
+                'form-1-email': ['email@email.com'],
                 'form-1-last_name': ['test2'],
                 'form-1-first_name': ['test2'],
                 'form-1-greeting': [''],
@@ -511,7 +511,7 @@ class TestViews(TestCase):
         self.assertEqual(len(mail.outbox), 0)
 
     def test_forgotten_password(self):
-        """User forgets his password test"""
+        """User forgets their password test."""
         response = self.client.post(
             reverse('invite:amnesia'),
             {'email': 'normal@normal.normal'},
@@ -749,7 +749,7 @@ class TestViews(TestCase):
             {
                 'form-MAX_NUM_FORMS': [''],
                 'form-INITIAL_FORMS': ['0'],
-                'form-TOTAL_FORMS': ['2'],
+                'form-TOTAL_FORMS': ['1'],
                 'form-0-username': ['bobby'],
                 'form-0-email': ['test1@test.com'],
                 'form-0-last_name': ['test1'],
@@ -761,6 +761,7 @@ class TestViews(TestCase):
             reverse('invite:check'), {'email': 'test1@test.com'}
         )
         self.assertTrue(json.loads(response.content)['taken'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #69 and #70 

@ldko @somexpert This is ready for review.

Checking duplicate emails in Invites/Users
- This was a simple change. A function that checks the InviteItem against current Invites and returns if they have emails that are the same. A test was written for this.
- The error for this is rendered whenever the 'email' field in the form is changed. This should get displayed over the form in question.

Normalizes emails
- The `clean_email` function was overridden to strip whitespace and lowercase the value.
- This can be tested by creating a new invitation and looking at the email in the UI.

Check duplicate emails in current Invite form
- This issue sprang up from trying to resolve the first email issue. If there were duplicate emails in more than one row, Django would accept all of the rows regardless and there would be duplicate emails across several Invitations. 
- A formset was added to validate the emails in the form were all unique. 
- A new partial was added to the `invite.html` to render the error/s from the form. This new error div renders at the top of the form with the email in question included. This does not disable the submit button like the eventlistener validations do. This is because this particular check only happens server side rather than client side. 

To test these changes
- Create a Superuser if one doesn't exist with `./manage.py createsuperuser`.
- Try to create an Invitation with the same email as the superuser (should raise an error)
- Create an Invitation with a different value
- Try to create an Invitation with the same email as the just created Invitation (should raise an error).
- Create 2+ rows where 2+ have duplicate emails (should raise an error after the form is submitted). 